### PR TITLE
Makes it possible to retrieve the url of a thumbnail without the img tag

### DIFF
--- a/lib/middleman-thumbnailer/extension.rb
+++ b/lib/middleman-thumbnailer/extension.rb
@@ -47,16 +47,26 @@ module Middleman
     end
 
     module Helpers
+      def thumbnail_specs(image, name)
+        dimensions = Thumbnailer.options[:dimensions]
+        ThumbnailGenerator.specs(image, dimensions)
+      end
+
+      def thumbnail_url(image, name, options = {})
+        include_images_dir = options.delete :include_images_dir
+
+        url = thumbnail_specs(image, name)[name][:name]
+        url = File.join(images_dir, url) if include_images_dir
+
+        url
+      end
+
       def thumbnail(image, name, html_options = {})
-        options = Thumbnailer.options
-        dimensions = options[:dimensions]
-        specs = ThumbnailGenerator.specs(image, dimensions)
+        specs_for_data_attribute = thumbnail_specs(image, name).map {|name, spec| "#{name}:#{spec[:name]}"}
 
-        specs_for_data_attribute = specs.map {|name, spec| "#{name}:#{spec[:name]}"}
+        html_options.merge!({'data-thumbnails' => specs_for_data_attribute.join('|')}) if Thumbnailer.options[:include_data_thumbnails]
 
-        html_options.merge!({'data-thumbnails' => specs_for_data_attribute.join('|')}) if options[:include_data_thumbnails]
-
-        image_tag(specs[name][:name], html_options)
+        image_tag(thumbnail_url(image, name), html_options)
       end
     end
 


### PR DESCRIPTION
Fixes #2 and lets you insert the URL to a thumbnail instead of always using the full `<img>` tag.
