### PR TITLE
Fix missing comma in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And something like this to your `config.rb`:
       :small => '200x',
       :medium => '400x300'
     },
-    :include_data_thumbnails => true
+    :include_data_thumbnails => true,
     :namespace_directory => %w(gallery)
 ```
 


### PR DESCRIPTION
Currently throws an error when copy/pasted into `config.rb`

```
syntax error, unexpected tASSOC, expecting $end (SyntaxError)
  :namespace_directory => %w(images)
                         ^
```
